### PR TITLE
feat: add continuous integration github action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,41 @@
+name: "Continuous Integration"
+
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '1 1 * * 0'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9","3.12"]
+    
+    steps:
+    - name: Checkout Code for PRs
+      if: github.event_name == 'pull_request'
+      uses: actions/checkout@v4
+    - name: Checkout Code for Push/Schedule
+      if: github.event_name != 'pull_request'
+      uses: actions/checkout@v4
+      with:
+        ref: main
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python3 -m pip install --upgrade pip
+        pip3 install -r requirements.txt
+    - name: Run Example
+      run: |
+        python3 gnn_citation_networks.py


### PR DESCRIPTION
# Overview
This script utilizes github actions to automatically test the `gnn_citation_networks.py` script with 2 different versions of python. It will run on any PR that merges into the main branch, as well as once a week ([see github actions docs for `cron` format](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onschedule))

This will show automatically that the code either works or doesn't (including sending emails out to the repo admins). It will *ensure* that if code modifies any part of the scripts tested, then the final merged product will be fully functioning based on the script added in this PR. I would *strongly* recommend that the repo admins then change the branch rules of the repository to enforce a passing continuous integration check to allow for merges (and should enforce PR's with atleast one reviewer approval to merge into main)

For additional documentation on github actions see the docs [here](https://docs.github.com/en/actions)

# Discussion Points
I created this, being pretty new to this project, and in reference to #5 (which actually generates the same error there as well, [see the github action on my fork](https://github.com/joey-kilgore/sgnn-superneuro/actions/runs/14633763502/job/41060735751)) and so I don't know the following:
1. how long, assuming we fix the bug listed in #5, should this script take to run? It's probably not a good idea to have a github action linked to a job that takes 45min. Though it might be useful to have a job like that runs once a month just to ensure these long tasks keep functioning, but that kind of job doesn't need to run on every PR. I recommend that we choose a few setups. It is very easy to add Windows and MacOS runs as well, but those typically take a bit longer to run (due to machine allocation on the backend). Additionally, I have setup python3.9 and python3.12 support. I recommend that if there is cluster computer system that anyone in the group regularly uses and it has a specific version of python we use that (or if people are on newer/older versions than the ones listed here). And then we ensure the jobs we choose is <5min in length (note that it will run all OS+Python versions in parallel).
2. Is there another script we should run? I set it to the `gnn_citation_networks.py` because that's what is listed in the `README.md` but if there is another script that people suggest to be tested as well, then we should do that. Again, refer to (1) for notes on job length.